### PR TITLE
fix: voeg standalone output toe voor Coolify/Docker deployment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   images: {
       remotePatterns: [
         {


### PR DESCRIPTION
Voorkomt "Failed to find Server Action" fout op productie door een zelfstandige server bundel te genereren.